### PR TITLE
Normalise Windows TZ IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/jwijenbergh/purego v0.0.0-20251017112123-b71757b9ba42
 	github.com/jwijenbergh/puregotk v0.0.0-20260115100645-c78e1521129b
+	github.com/thommeo/winianatz v0.0.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6/go.mod h1:BEksegNspIkjCQfmzWgsgbu6KdeJ/4LwUZs7DMBzjzw=
 github.com/emersion/go-ical v0.0.0-20250609112844-439c63cef608 h1:5XWaET4YAcppq3l1/Yh2ay5VmQjUdq6qhJuucdGbmOY=
 github.com/emersion/go-ical v0.0.0-20250609112844-439c63cef608/go.mod h1:BEksegNspIkjCQfmzWgsgbu6KdeJ/4LwUZs7DMBzjzw=
@@ -20,8 +22,14 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
+github.com/thommeo/winianatz v0.0.2 h1:x9VywTyCQL8+aN1FK46fE9+8QGsR2RKyUwilLMwFuxA=
+github.com/thommeo/winianatz v0.0.2/go.mod h1:fzwROCdZKIS6n/rXKgDwpSTNCXOT7iJXwClrC9I4/sw=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/calendar/caldav.go
+++ b/internal/calendar/caldav.go
@@ -193,6 +193,8 @@ func (s *CalDAVSource) parseCalendarObject(data *ics.Calendar, calName string) (
 
 // parseEventComponent converts an ICS VEVENT to our Event type.
 func (s *CalDAVSource) parseEventComponent(comp *ics.Component, calName string) (Event, error) {
+	normalizeComponentTimezones(comp)
+
 	event := Event{
 		Source: fmt.Sprintf("%s/%s", s.name, calName),
 	}

--- a/internal/calendar/ics.go
+++ b/internal/calendar/ics.go
@@ -108,6 +108,8 @@ func (s *ICSSource) parseICS(r io.Reader) ([]Event, error) {
 // parseEvent converts an ICS VEVENT component to our Event type.
 // For recurring events, it expands occurrences within the configured time range.
 func (s *ICSSource) parseEvent(comp *ics.Component) ([]Event, error) {
+	normalizeComponentTimezones(comp)
+
 	base := Event{
 		Source: s.name,
 	}

--- a/internal/calendar/ics_test.go
+++ b/internal/calendar/ics_test.go
@@ -8,6 +8,16 @@ import (
 	ics "github.com/emersion/go-ical"
 )
 
+func withLocalTimezone(t *testing.T, loc *time.Location) {
+	t.Helper()
+
+	prev := time.Local
+	time.Local = loc
+	t.Cleanup(func() {
+		time.Local = prev
+	})
+}
+
 func TestParseEvent_EffectivelyAllDay(t *testing.T) {
 	// Simulate an iCloud-style multi-day event encoded with full datetimes at midnight
 	icsData := `BEGIN:VCALENDAR
@@ -125,6 +135,54 @@ END:VCALENDAR`
 		}
 		if events[0].AllDay {
 			t.Errorf("expected AllDay=false for timed event, got true")
+		}
+	}
+}
+
+func TestParseEvent_WindowsTZIDConvertedToLocalTime(t *testing.T) {
+	gmt := time.FixedZone("GMT", 0)
+	withLocalTimezone(t, gmt)
+
+	icsData := `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-windows-tzid
+SUMMARY:Remote meeting
+DTSTART;TZID=GTB Standard Time:20260219T124000
+DTEND;TZID=GTB Standard Time:20260219T131000
+END:VEVENT
+END:VCALENDAR`
+
+	dec := ics.NewDecoder(strings.NewReader(icsData))
+	cal, err := dec.Decode()
+	if err != nil {
+		t.Fatalf("failed to decode ICS: %v", err)
+	}
+
+	s := &ICSSource{
+		name: "test",
+		end:  time.Date(2026, 3, 1, 0, 0, 0, 0, gmt),
+	}
+
+	for _, child := range cal.Children {
+		if child.Name != ics.CompEvent {
+			continue
+		}
+
+		events, err := s.parseEvent(child)
+		if err != nil {
+			t.Fatalf("parseEvent error: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(events))
+		}
+
+		wantStart := time.Date(2026, 2, 19, 10, 40, 0, 0, gmt)
+		wantEnd := time.Date(2026, 2, 19, 11, 10, 0, 0, gmt)
+		if got := events[0].Start.In(gmt); !got.Equal(wantStart) {
+			t.Fatalf("unexpected start: got %s want %s", got, wantStart)
+		}
+		if got := events[0].End.In(gmt); !got.Equal(wantEnd) {
+			t.Fatalf("unexpected end: got %s want %s", got, wantEnd)
 		}
 	}
 }

--- a/internal/calendar/merge.go
+++ b/internal/calendar/merge.go
@@ -152,6 +152,8 @@ func ParseICS(r io.Reader) ([]Event, error) {
 
 // parseEventComponent converts an ICS VEVENT component to our Event type.
 func parseEventComponent(comp *ics.Component) (Event, error) {
+	normalizeComponentTimezones(comp)
+
 	event := Event{}
 
 	// UID

--- a/internal/calendar/tzid.go
+++ b/internal/calendar/tzid.go
@@ -5,32 +5,9 @@ import (
 	"time"
 
 	ics "github.com/emersion/go-ical"
+	"github.com/thommeo/winianatz"
 )
 
-// windowsTZIDToIANA maps common Microsoft timezone IDs used in ICS feeds to IANA
-// names that Go can resolve via time.LoadLocation.
-var windowsTZIDToIANA = map[string]string{
-	"AUS Eastern Standard Time":       "Australia/Sydney",
-	"Cen. Australia Standard Time":    "Australia/Adelaide",
-	"Central Europe Standard Time":    "Europe/Budapest",
-	"Central European Standard Time":  "Europe/Warsaw",
-	"Central Standard Time":           "America/Chicago",
-	"E. Africa Standard Time":         "Africa/Nairobi",
-	"E. Australia Standard Time":      "Australia/Brisbane",
-	"E. Europe Standard Time":         "Europe/Chisinau",
-	"Eastern Standard Time":           "America/New_York",
-	"FLE Standard Time":               "Europe/Kiev",
-	"GTB Standard Time":               "Europe/Bucharest",
-	"GMT Standard Time":               "Europe/London",
-	"Greenwich Standard Time":         "Atlantic/Reykjavik",
-	"Mountain Standard Time":          "America/Denver",
-	"Pacific Standard Time":           "America/Los_Angeles",
-	"Romance Standard Time":           "Europe/Paris",
-	"SA Pacific Standard Time":        "America/Bogota",
-	"W. Europe Standard Time":         "Europe/Berlin",
-	"W. Central Africa Standard Time": "Africa/Lagos",
-	"UTC":                             "UTC",
-}
 
 // normalizeComponentTimezones converts the ICS component's timezone to IANA
 // timezones.
@@ -71,9 +48,11 @@ func normalizeTZID(tzid string) string {
 	if _, err := time.LoadLocation(tzid); err == nil {
 		return tzid
 	}
-	if mapped, ok := windowsTZIDToIANA[tzid]; ok {
-		if _, err := time.LoadLocation(mapped); err == nil {
-			return mapped
+
+	entry, err := winianatz.FromMicrosoftAlias(tzid)
+	if err == nil {
+		if _, err := time.LoadLocation(entry.IANA); err == nil {
+			return entry.IANA
 		}
 	}
 

--- a/internal/calendar/tzid.go
+++ b/internal/calendar/tzid.go
@@ -1,0 +1,81 @@
+package calendar
+
+import (
+	"strings"
+	"time"
+
+	ics "github.com/emersion/go-ical"
+)
+
+// windowsTZIDToIANA maps common Microsoft timezone IDs used in ICS feeds to IANA
+// names that Go can resolve via time.LoadLocation.
+var windowsTZIDToIANA = map[string]string{
+	"AUS Eastern Standard Time":       "Australia/Sydney",
+	"Cen. Australia Standard Time":    "Australia/Adelaide",
+	"Central Europe Standard Time":    "Europe/Budapest",
+	"Central European Standard Time":  "Europe/Warsaw",
+	"Central Standard Time":           "America/Chicago",
+	"E. Africa Standard Time":         "Africa/Nairobi",
+	"E. Australia Standard Time":      "Australia/Brisbane",
+	"E. Europe Standard Time":         "Europe/Chisinau",
+	"Eastern Standard Time":           "America/New_York",
+	"FLE Standard Time":               "Europe/Kiev",
+	"GTB Standard Time":               "Europe/Bucharest",
+	"GMT Standard Time":               "Europe/London",
+	"Greenwich Standard Time":         "Atlantic/Reykjavik",
+	"Mountain Standard Time":          "America/Denver",
+	"Pacific Standard Time":           "America/Los_Angeles",
+	"Romance Standard Time":           "Europe/Paris",
+	"SA Pacific Standard Time":        "America/Bogota",
+	"W. Europe Standard Time":         "Europe/Berlin",
+	"W. Central Africa Standard Time": "Africa/Lagos",
+	"UTC":                             "UTC",
+}
+
+// normalizeComponentTimezones converts the ICS component's timezone to IANA
+// timezones.
+func normalizeComponentTimezones(comp *ics.Component) {
+	for name, props := range comp.Props {
+		changed := false
+
+		for i := range props {
+			tzid := props[i].Params.Get(ics.PropTimezoneID)
+
+			normalized := normalizeTZID(tzid)
+			if normalized == "" || normalized == tzid {
+				continue
+			}
+
+			props[i].Params.Set(ics.PropTimezoneID, normalized)
+			changed = true
+		}
+
+		if changed {
+			comp.Props[name] = props
+		}
+	}
+
+	for _, child := range comp.Children {
+		normalizeComponentTimezones(child)
+	}
+}
+
+// normalizeTZID converts the given timezone string from Windows timezone ID to
+// an IANA timezone.
+func normalizeTZID(tzid string) string {
+	tzid = strings.Trim(strings.TrimSpace(tzid), "\"")
+	if tzid == "" {
+		return ""
+	}
+
+	if _, err := time.LoadLocation(tzid); err == nil {
+		return tzid
+	}
+	if mapped, ok := windowsTZIDToIANA[tzid]; ok {
+		if _, err := time.LoadLocation(mapped); err == nil {
+			return mapped
+		}
+	}
+
+	return tzid
+}


### PR DESCRIPTION
Adds normalisation of Windows Timezone IDs to allow Go date time-zone parsing to work with Office365 calendar events.

Resolves #1.